### PR TITLE
Fix datatype for Course endYear attribute

### DIFF
--- a/src/ic_parent_api/models/base.py
+++ b/src/ic_parent_api/models/base.py
@@ -126,7 +126,7 @@ class CourseResponse(BaseModel):
     courseNumber: str
     isResponsive: bool
     sectionNumber: str
-    endYear: str
+    endYear: int
     schoolName: str
     trialID: int
     trialActive: bool


### PR DESCRIPTION
get_courses() fails because it is expecting endYear to be an str instead of an int:

```
Traceback (most recent call last):
  File "/Users/brian/code/icapi/icapi/./course.py", line 168, in <module>
    printCourses()
  File "/Users/brian/code/icapi/icapi/./course.py", line 68, in printCourses
    courses = asyncio.run(get_courses())
  File "/opt/homebrew/Cellar/python@3.10/3.10.7/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/opt/homebrew/Cellar/python@3.10/3.10.7/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/Users/brian/code/icapi/icapi/./course.py", line 35, in get_courses
    return await client.courses(1499)
  File "/Users/brian/Library/Caches/pypoetry/virtualenvs/icapi-x1CbIzMR-py3.10/lib/python3.10/site-packages/ic_parent_api/infinitecampus.py", line 43, in courses
    coursesresp = await self._api_client.get_courses(student_id)
  File "/Users/brian/Library/Caches/pypoetry/virtualenvs/icapi-x1CbIzMR-py3.10/lib/python3.10/site-packages/ic_parent_api/ic_api_client.py", line 95, in get_courses
    return [CourseResponse(**resp) for resp in parsed_response]
  File "/Users/brian/Library/Caches/pypoetry/virtualenvs/icapi-x1CbIzMR-py3.10/lib/python3.10/site-packages/ic_parent_api/ic_api_client.py", line 95, in <listcomp>
    return [CourseResponse(**resp) for resp in parsed_response]
  File "/Users/brian/Library/Caches/pypoetry/virtualenvs/icapi-x1CbIzMR-py3.10/lib/python3.10/site-packages/pydantic/main.py", line 209, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for CourseResponse
endYear
  Input should be a valid string [type=string_type, input_value=2025, input_type=int]
    For further information visit https://errors.pydantic.dev/2.9/v/string_type```