### PR TITLE
Add grades, attendance, and inbox messages support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ The types of objects that can be returned include:
 - Courses
 - Assignments
 - Terms
+- **Grades** - Posted and in-progress grades by term
+- **Attendance** - Absences and tardies by term
+- **Messages** - Inbox messages from teachers/school
 
 This module is provided for use with the Home Assistant custom integration [Infinite Campus](https://github.com/schwartzpub/infinite_campus_hassio) however it could be useful as a standalone module for your own projects as well.
 
@@ -44,4 +47,58 @@ students = asyncio.run(get_students())
 
 for student in students:
     print(student.firstname)
+```
+
+### Getting Grades
+
+```python
+async def get_grades():
+    client = InfiniteCampus(f"{base_url}",f"{username}",f"{password}",f"{district}")
+    students = await client.students()
+
+    for student in students:
+        grades = await client.grades(student.personid)
+        for grade in grades:
+            for term in grade.terms:
+                print(f"\n{term.termname}:")
+                for course in term.courses:
+                    print(f"  {course.coursename}: {course.grade}")
+
+asyncio.run(get_grades())
+```
+
+### Getting Attendance
+
+```python
+async def get_attendance():
+    client = InfiniteCampus(f"{base_url}",f"{username}",f"{password}",f"{district}")
+    students = await client.students()
+
+    for student in students:
+        for enrollment in student.enrollments:
+            attendance = await client.attendance(enrollment.enrollmentid, student.personid)
+            for term in attendance.terms:
+                print(f"{term.termname}: {term.totalabsent} absences, {term.totaltardy} tardies")
+
+asyncio.run(get_attendance())
+```
+
+### Getting Inbox Messages
+
+```python
+async def get_messages():
+    client = InfiniteCampus(f"{base_url}",f"{username}",f"{password}",f"{district}")
+    messages = await client.messages()
+
+    for msg in messages[:10]:  # First 10 messages
+        print(f"{msg.date}: {msg.subject}")
+        print(f"  Student: {msg.studentname}")
+        print(f"  Course: {msg.coursename}")
+
+        # Get full message content
+        detail = await client.message_detail(msg)
+        if detail.body_text:
+            print(f"  Content: {detail.body_text[:200]}...")
+
+asyncio.run(get_messages())
 ```

--- a/src/ic_parent_api/ic_api_client.py
+++ b/src/ic_parent_api/ic_api_client.py
@@ -7,7 +7,8 @@ import aiohttp
 
 from .errors import InfiniteCampusError
 from .models.base import StudentResponse, CourseResponse, \
-    AssignmentResponse, TermResponse, ScheduleDayResponse
+    AssignmentResponse, TermResponse, ScheduleDayResponse, \
+    GradeResponse, AttendanceResponse, MessageResponse
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.INFO)
@@ -119,3 +120,46 @@ class InfiniteCampusApiClient():
         if parsed_response:
             return [ScheduleDayResponse(**resp) for resp in parsed_response]
         return []
+
+    async def get_grades(self, student_id: int) -> list[GradeResponse]:
+        """Get Infinite Campus Grades for a student."""
+        parsed_response = await self._get_request(
+            f"/campus/resources/portal/grades?personID={student_id}"
+        )
+        if parsed_response:
+            return [GradeResponse(**resp) for resp in parsed_response]
+        return []
+
+    async def get_attendance(self, enrollment_id: int, student_id: int) -> AttendanceResponse:
+        """Get Infinite Campus Attendance for a student enrollment."""
+        parsed_response = await self._get_request(
+            f"/campus/resources/portal/attendance/{enrollment_id}"
+            f"?courseSummary=true&personID={student_id}"
+        )
+        if parsed_response:
+            return AttendanceResponse(**parsed_response)
+        return AttendanceResponse(terms=[])
+
+    async def get_messages(self) -> list[MessageResponse]:
+        """Get Infinite Campus Inbox Messages."""
+        parsed_response = await self._get_request(
+            "/campus/api/portal/process-message"
+        )
+        if parsed_response:
+            return [MessageResponse(**resp) for resp in parsed_response]
+        return []
+
+    async def get_message_detail(
+        self,
+        message_id: str,
+        message_recipient_id: str,
+        process_message_id: str
+    ) -> dict:
+        """Get full message content."""
+        parsed_response = await self._get_request(
+            f"/campus/prism?x=messenger.MessengerEngine-getMessageRecipientView"
+            f"&messageID={message_id}"
+            f"&messageRecipientID={message_recipient_id}"
+            f"&processMessageID={process_message_id}"
+        )
+        return parsed_response or {}

--- a/src/ic_parent_api/infinitecampus.py
+++ b/src/ic_parent_api/infinitecampus.py
@@ -5,6 +5,9 @@ from .models.student import Student
 from .models.course import Course
 from .models.assignment import Assignment
 from .models.term import Term
+from .models.grade import Grade
+from .models.attendance import Attendance
+from .models.message import Message, MessageDetail
 from .ic_api_client import InfiniteCampusApiClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,3 +58,32 @@ class InfiniteCampus():
         termsresp = await self._api_client.get_terms()
         terms = [Term(response) for response in termsresp]
         return terms
+
+    async def grades(self, student_id: int) -> list[Grade]:
+        """Get Grades: must supply student id (personID)."""
+        gradesresp = await self._api_client.get_grades(student_id)
+        grades = [Grade(response) for response in gradesresp]
+        return grades
+
+    async def attendance(self, enrollment_id: int, student_id: int) -> Attendance:
+        """Get Attendance: must supply enrollment id and student id (personID)."""
+        attendanceresp = await self._api_client.get_attendance(enrollment_id, student_id)
+        return Attendance(attendanceresp)
+
+    async def messages(self) -> list[Message]:
+        """Get Inbox Messages."""
+        messagesresp = await self._api_client.get_messages()
+        messages = [Message(response) for response in messagesresp]
+        return messages
+
+    async def message_detail(self, message: Message) -> MessageDetail:
+        """Get full message content: must supply a Message object."""
+        ids = message.parse_url_ids()
+        if not ids:
+            return MessageDetail({})
+        detail = await self._api_client.get_message_detail(
+            ids['message_id'],
+            ids['message_recipient_id'],
+            ids['process_message_id']
+        )
+        return MessageDetail(detail)

--- a/src/ic_parent_api/models/attendance.py
+++ b/src/ic_parent_api/models/attendance.py
@@ -1,0 +1,95 @@
+"""Attendance Model Definition."""
+from typing import Optional
+from ic_parent_api.base import DataModel
+from ic_parent_api.models.base import AttendanceResponse
+
+
+class AttendanceCourse(DataModel):
+    """Attendance Course Model Definition."""
+    def __init__(self, course_data: dict):
+        self._courseid = course_data.get('courseID')
+        self._coursename = course_data.get('courseName')
+        self._sectionid = course_data.get('sectionID')
+        self._totalabsent = course_data.get('totalAbsent', 0) or 0
+        self._totaltardy = course_data.get('totalTardy', 0) or 0
+        self._totalexcused = course_data.get('totalExcused', 0) or 0
+        self._totalunexcused = course_data.get('totalUnexcused', 0) or 0
+
+    @property
+    def courseid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._courseid
+
+    @property
+    def coursename(self) -> Optional[str]:
+        """Property Definition."""
+        return self._coursename
+
+    @property
+    def sectionid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._sectionid
+
+    @property
+    def totalabsent(self) -> float:
+        """Total absences for this course."""
+        return self._totalabsent
+
+    @property
+    def totaltardy(self) -> float:
+        """Total tardies for this course."""
+        return self._totaltardy
+
+    @property
+    def totalexcused(self) -> float:
+        """Total excused absences for this course."""
+        return self._totalexcused
+
+    @property
+    def totalunexcused(self) -> float:
+        """Total unexcused absences for this course."""
+        return self._totalunexcused
+
+
+class AttendanceTerm(DataModel):
+    """Attendance Term Model Definition."""
+    def __init__(self, term_data: dict):
+        self._termid = term_data.get('termID')
+        self._termname = term_data.get('termName')
+        self._courses = term_data.get('courses', [])
+
+    @property
+    def termid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._termid
+
+    @property
+    def termname(self) -> Optional[str]:
+        """Property Definition."""
+        return self._termname
+
+    @property
+    def courses(self) -> list[AttendanceCourse]:
+        """Property Definition."""
+        return [AttendanceCourse(course) for course in self._courses]
+
+    @property
+    def totalabsent(self) -> float:
+        """Total absences across all courses for this term."""
+        return sum(course.totalabsent for course in self.courses)
+
+    @property
+    def totaltardy(self) -> float:
+        """Total tardies across all courses for this term."""
+        return sum(course.totaltardy for course in self.courses)
+
+
+class Attendance(DataModel):
+    """Attendance Model Definition."""
+    def __init__(self, attendance_resp: AttendanceResponse):
+        self._terms = attendance_resp.terms or []
+
+    @property
+    def terms(self) -> list[AttendanceTerm]:
+        """Property Definition."""
+        return [AttendanceTerm(term.model_dump()) for term in self._terms]

--- a/src/ic_parent_api/models/base.py
+++ b/src/ic_parent_api/models/base.py
@@ -185,3 +185,131 @@ class AssignmentResponse(BaseModel):
     isValidRubric: Optional[bool] = None
     isValidMark: Optional[bool] = None
     includeCampusLearning: Optional[bool] = None
+
+
+class GradingTaskResponse(BaseModel):
+    """Grading Task Response Definition."""
+    class Config:
+        extra = 'ignore'
+    personID: int
+    trialID: Optional[int] = None
+    calendarID: Optional[int] = None
+    structureID: Optional[int] = None
+    courseID: Optional[int] = None
+    courseName: Optional[str] = None
+    sectionID: Optional[int] = None
+    taskID: Optional[int] = None
+    termID: Optional[int] = None
+    taskName: Optional[str] = None
+    score: Optional[str] = None
+    progressScore: Optional[str] = None
+    progressPercent: Optional[float] = None
+    scoreID: Optional[int] = None
+    gradedOnce: Optional[bool] = None
+    hasAssignments: Optional[bool] = None
+
+
+class GradeCourseResponse(BaseModel):
+    """Grade Course Response Definition."""
+    class Config:
+        extra = 'ignore'
+    id: Optional[str] = Field(default=None, alias='_id')
+    rosterID: Optional[int] = None
+    personID: Optional[int] = None
+    courseID: Optional[int] = None
+    sectionID: Optional[int] = None
+    courseName: Optional[str] = None
+    courseNumber: Optional[str] = None
+    teacherDisplay: Optional[str] = None
+    gradingTasks: Optional[list[GradingTaskResponse]] = None
+
+
+class GradeTermResponse(BaseModel):
+    """Grade Term Response Definition."""
+    class Config:
+        extra = 'ignore'
+    calendarID: Optional[int] = None
+    termID: Optional[int] = None
+    termName: Optional[str] = None
+    termScheduleID: Optional[int] = None
+    termScheduleName: Optional[str] = None
+    termSeq: Optional[int] = None
+    isPrimary: Optional[bool] = None
+    startDate: Optional[str] = None
+    endDate: Optional[str] = None
+    courses: Optional[list[GradeCourseResponse]] = None
+
+
+class GradeResponse(BaseModel):
+    """Grade Response Definition (enrollment level)."""
+    class Config:
+        extra = 'ignore'
+    enrollmentID: Optional[int] = None
+    terms: Optional[list[GradeTermResponse]] = None
+
+
+class AttendanceCourseResponse(BaseModel):
+    """Attendance Course Response Definition."""
+    class Config:
+        extra = 'ignore'
+    courseID: Optional[int] = None
+    courseName: Optional[str] = None
+    sectionID: Optional[int] = None
+    totalAbsent: Optional[float] = None
+    totalTardy: Optional[float] = None
+    totalExcused: Optional[float] = None
+    totalUnexcused: Optional[float] = None
+
+
+class AttendanceTermResponse(BaseModel):
+    """Attendance Term Response Definition."""
+    class Config:
+        extra = 'ignore'
+    termID: Optional[int] = None
+    termName: Optional[str] = None
+    courses: Optional[list[AttendanceCourseResponse]] = None
+
+
+class AttendanceResponse(BaseModel):
+    """Attendance Response Definition."""
+    class Config:
+        extra = 'ignore'
+    terms: Optional[list[AttendanceTermResponse]] = None
+
+
+class MessageResponse(BaseModel):
+    """Message Response Definition."""
+    class Config:
+        extra = 'ignore'
+    messageID: Optional[int] = None
+    contextID: Optional[int] = None
+    actionRequired: Optional[bool] = None
+    postedTimestamp: Optional[str] = None
+    date: Optional[str] = None
+    name: Optional[str] = None
+    dueDate: Optional[str] = None
+    newMessage: Optional[bool] = None
+    personID: Optional[int] = None
+    process: Optional[str] = None
+    url: Optional[str] = None
+    sectionID: Optional[int] = None
+    schoolID: Optional[int] = None
+    calendarID: Optional[int] = None
+    sender: Optional[str] = None
+    studentID: Optional[int] = None
+    studentName: Optional[str] = None
+    courseID: Optional[int] = None
+    courseName: Optional[str] = None
+    messageType: Optional[str] = None
+
+
+class MessageDetailResponse(BaseModel):
+    """Message Detail Response Definition."""
+    class Config:
+        extra = 'ignore'
+    messageID: Optional[str] = None
+    createdTimeStamp: Optional[str] = None
+    deliveryTimeStamp: Optional[str] = None
+    senderID: Optional[str] = None
+    subject: Optional[str] = None
+    body: Optional[str] = None

--- a/src/ic_parent_api/models/grade.py
+++ b/src/ic_parent_api/models/grade.py
@@ -1,0 +1,181 @@
+"""Grade Model Definition."""
+from typing import Optional
+from ic_parent_api.base import DataModel
+from ic_parent_api.models.base import GradeResponse, GradeTermResponse, GradeCourseResponse
+
+
+class GradingTask(DataModel):
+    """Grading Task Model Definition."""
+    def __init__(self, task_data: dict):
+        self._personid = task_data.get('personID')
+        self._courseid = task_data.get('courseID')
+        self._coursename = task_data.get('courseName')
+        self._taskid = task_data.get('taskID')
+        self._taskname = task_data.get('taskName')
+        self._termid = task_data.get('termID')
+        self._score = task_data.get('score')
+        self._progressscore = task_data.get('progressScore')
+        self._progresspercent = task_data.get('progressPercent')
+        self._scoreid = task_data.get('scoreID')
+
+    @property
+    def personid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._personid
+
+    @property
+    def courseid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._courseid
+
+    @property
+    def coursename(self) -> Optional[str]:
+        """Property Definition."""
+        return self._coursename
+
+    @property
+    def taskid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._taskid
+
+    @property
+    def taskname(self) -> Optional[str]:
+        """Property Definition."""
+        return self._taskname
+
+    @property
+    def termid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._termid
+
+    @property
+    def score(self) -> Optional[str]:
+        """Posted grade (e.g., 'A', 'B+')."""
+        return self._score
+
+    @property
+    def progressscore(self) -> Optional[str]:
+        """In-progress grade."""
+        return self._progressscore
+
+    @property
+    def progresspercent(self) -> Optional[float]:
+        """In-progress percentage."""
+        return self._progresspercent
+
+    @property
+    def scoreid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._scoreid
+
+    @property
+    def grade(self) -> Optional[str]:
+        """Get the best available grade (posted or in-progress)."""
+        return self._score or self._progressscore
+
+
+class GradeCourse(DataModel):
+    """Grade Course Model Definition."""
+    def __init__(self, course_data: dict):
+        self._courseid = course_data.get('courseID')
+        self._coursename = course_data.get('courseName')
+        self._coursenumber = course_data.get('courseNumber')
+        self._sectionid = course_data.get('sectionID')
+        self._teacherdisplay = course_data.get('teacherDisplay')
+        self._gradingtasks = course_data.get('gradingTasks', [])
+
+    @property
+    def courseid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._courseid
+
+    @property
+    def coursename(self) -> Optional[str]:
+        """Property Definition."""
+        return self._coursename
+
+    @property
+    def coursenumber(self) -> Optional[str]:
+        """Property Definition."""
+        return self._coursenumber
+
+    @property
+    def sectionid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._sectionid
+
+    @property
+    def teacherdisplay(self) -> Optional[str]:
+        """Property Definition."""
+        return self._teacherdisplay
+
+    @property
+    def gradingtasks(self) -> list[GradingTask]:
+        """Property Definition."""
+        return [GradingTask(task) for task in self._gradingtasks]
+
+    @property
+    def grade(self) -> Optional[str]:
+        """Get the primary grade for this course."""
+        for task in self.gradingtasks:
+            if task.grade:
+                return task.grade
+        return None
+
+
+class GradeTerm(DataModel):
+    """Grade Term Model Definition."""
+    def __init__(self, term_data: dict):
+        self._termid = term_data.get('termID')
+        self._termname = term_data.get('termName')
+        self._termseq = term_data.get('termSeq')
+        self._startdate = term_data.get('startDate')
+        self._enddate = term_data.get('endDate')
+        self._courses = term_data.get('courses', [])
+
+    @property
+    def termid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._termid
+
+    @property
+    def termname(self) -> Optional[str]:
+        """Property Definition."""
+        return self._termname
+
+    @property
+    def termseq(self) -> Optional[int]:
+        """Property Definition."""
+        return self._termseq
+
+    @property
+    def startdate(self) -> Optional[str]:
+        """Property Definition."""
+        return self._startdate
+
+    @property
+    def enddate(self) -> Optional[str]:
+        """Property Definition."""
+        return self._enddate
+
+    @property
+    def courses(self) -> list[GradeCourse]:
+        """Property Definition."""
+        return [GradeCourse(course) for course in self._courses]
+
+
+class Grade(DataModel):
+    """Grade Model Definition (enrollment level)."""
+    def __init__(self, grade_resp: GradeResponse):
+        self._enrollmentid = grade_resp.enrollmentID
+        self._terms = grade_resp.terms or []
+
+    @property
+    def enrollmentid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._enrollmentid
+
+    @property
+    def terms(self) -> list[GradeTerm]:
+        """Property Definition."""
+        return [GradeTerm(term.model_dump()) for term in self._terms]

--- a/src/ic_parent_api/models/message.py
+++ b/src/ic_parent_api/models/message.py
@@ -1,0 +1,209 @@
+"""Message Model Definition."""
+import re
+import html
+from typing import Optional
+from ic_parent_api.base import DataModel
+from ic_parent_api.models.base import MessageResponse, MessageDetailResponse
+
+
+class Message(DataModel):
+    """Message Model Definition."""
+    def __init__(self, message_resp: MessageResponse):
+        self._messageid = message_resp.messageID
+        self._actionrequired = message_resp.actionRequired
+        self._postedtimestamp = message_resp.postedTimestamp
+        self._date = message_resp.date
+        self._name = message_resp.name
+        self._duedate = message_resp.dueDate
+        self._newmessage = message_resp.newMessage
+        self._personid = message_resp.personID
+        self._process = message_resp.process
+        self._url = message_resp.url
+        self._sectionid = message_resp.sectionID
+        self._schoolid = message_resp.schoolID
+        self._calendarid = message_resp.calendarID
+        self._sender = message_resp.sender
+        self._studentid = message_resp.studentID
+        self._studentname = message_resp.studentName
+        self._courseid = message_resp.courseID
+        self._coursename = message_resp.courseName
+        self._messagetype = message_resp.messageType
+
+    @property
+    def messageid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._messageid
+
+    @property
+    def actionrequired(self) -> Optional[bool]:
+        """Property Definition."""
+        return self._actionrequired
+
+    @property
+    def postedtimestamp(self) -> Optional[str]:
+        """Property Definition."""
+        return self._postedtimestamp
+
+    @property
+    def date(self) -> Optional[str]:
+        """Property Definition."""
+        return self._date
+
+    @property
+    def name(self) -> Optional[str]:
+        """Message subject/name."""
+        return self._name
+
+    @property
+    def subject(self) -> Optional[str]:
+        """Alias for name (message subject)."""
+        return self._name
+
+    @property
+    def duedate(self) -> Optional[str]:
+        """Property Definition."""
+        return self._duedate
+
+    @property
+    def newmessage(self) -> Optional[bool]:
+        """Whether this is an unread message."""
+        return self._newmessage
+
+    @property
+    def personid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._personid
+
+    @property
+    def process(self) -> Optional[str]:
+        """Property Definition."""
+        return self._process
+
+    @property
+    def url(self) -> Optional[str]:
+        """URL to view message details."""
+        return self._url
+
+    @property
+    def sectionid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._sectionid
+
+    @property
+    def schoolid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._schoolid
+
+    @property
+    def calendarid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._calendarid
+
+    @property
+    def sender(self) -> Optional[str]:
+        """Property Definition."""
+        return self._sender
+
+    @property
+    def studentid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._studentid
+
+    @property
+    def studentname(self) -> Optional[str]:
+        """Property Definition."""
+        return self._studentname
+
+    @property
+    def courseid(self) -> Optional[int]:
+        """Property Definition."""
+        return self._courseid
+
+    @property
+    def coursename(self) -> Optional[str]:
+        """Property Definition."""
+        return self._coursename
+
+    @property
+    def messagetype(self) -> Optional[str]:
+        """Property Definition."""
+        return self._messagetype
+
+    def parse_url_ids(self) -> Optional[dict]:
+        """Parse message IDs from URL for fetching full content."""
+        if not self._url:
+            return None
+        match = re.search(
+            r'messageID=(\d+)&messageRecipientID=(\d+)&processMessageID=(\d+)',
+            self._url
+        )
+        if match:
+            return {
+                'message_id': match.group(1),
+                'message_recipient_id': match.group(2),
+                'process_message_id': match.group(3)
+            }
+        return None
+
+
+class MessageDetail(DataModel):
+    """Message Detail Model Definition (full message content)."""
+    def __init__(self, detail_data: dict):
+        # Navigate nested response structure
+        data = detail_data.get('data', {})
+        msg_view = data.get('MessageRecipientView', {})
+        msg = msg_view.get('Message', {})
+
+        self._messageid = msg.get('messageID')
+        self._createdtimestamp = msg.get('createdTimeStamp')
+        self._deliverytimestamp = msg.get('deliveryTimeStamp')
+        self._senderid = msg.get('senderID')
+        self._subject = msg.get('subject')
+        self._body = msg.get('body')
+
+    @property
+    def messageid(self) -> Optional[str]:
+        """Property Definition."""
+        return self._messageid
+
+    @property
+    def createdtimestamp(self) -> Optional[str]:
+        """Property Definition."""
+        return self._createdtimestamp
+
+    @property
+    def deliverytimestamp(self) -> Optional[str]:
+        """Property Definition."""
+        return self._deliverytimestamp
+
+    @property
+    def senderid(self) -> Optional[str]:
+        """Property Definition."""
+        return self._senderid
+
+    @property
+    def subject(self) -> Optional[str]:
+        """Property Definition."""
+        return self._subject
+
+    @property
+    def body(self) -> Optional[str]:
+        """Raw HTML body of the message."""
+        return self._body
+
+    @property
+    def body_text(self) -> Optional[str]:
+        """Clean plain text version of the message body."""
+        if not self._body:
+            return None
+        # Remove style block content
+        clean = re.sub(r'<style[^>]*>.*?</style>', '', self._body, flags=re.DOTALL)
+        # Remove HTML tags
+        clean = re.sub(r'<[^>]+>', ' ', clean)
+        # Normalize whitespace
+        clean = re.sub(r'\s+', ' ', clean).strip()
+        # Unescape HTML entities
+        clean = html.unescape(clean)
+        # Remove XML declaration
+        clean = re.sub(r'<\?xml[^>]+\?>', '', clean)
+        return clean.strip()

--- a/test_new_features.py
+++ b/test_new_features.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Test script for new grades, attendance, and messages features.
+Uses credentials from ../kids/.env
+"""
+
+import asyncio
+import sys
+import os
+
+# Add src to path so we can import the local modified library
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+from dotenv import load_dotenv
+from ic_parent_api import InfiniteCampus
+
+# Load credentials from kids folder
+load_dotenv('/Users/nateober/kids/.env')
+
+
+async def test_all_features():
+    """Test all new features."""
+    client = InfiniteCampus(
+        os.getenv("IC_BASE_URL"),
+        os.getenv("IC_USERNAME"),
+        os.getenv("IC_PASSWORD"),
+        os.getenv("IC_DISTRICT")
+    )
+
+    print("=" * 60)
+    print("Testing ic_parent_api new features")
+    print("=" * 60)
+
+    # Test 1: Get students (existing feature)
+    print("\n[TEST 1] Getting students...")
+    try:
+        students = await client.students()
+        print(f"  ✓ Found {len(students)} students")
+        for s in students:
+            print(f"    - {s.firstname} {s.lastname} (ID: {s.personid})")
+    except Exception as e:
+        print(f"  ✗ Failed: {e}")
+        return
+
+    # Test 2: Get grades (new feature)
+    print("\n[TEST 2] Getting grades...")
+    try:
+        for student in students:
+            print(f"\n  {student.firstname} {student.lastname}:")
+            grades = await client.grades(student.personid)
+            if grades:
+                for grade in grades:
+                    for term in grade.terms:
+                        print(f"    {term.termname}:")
+                        for course in term.courses[:3]:  # First 3 courses
+                            print(f"      {course.coursename}: {course.grade or '--'}")
+                        if len(term.courses) > 3:
+                            print(f"      ... and {len(term.courses) - 3} more courses")
+            else:
+                print("    No grades found")
+        print("  ✓ Grades test passed")
+    except Exception as e:
+        print(f"  ✗ Failed: {e}")
+        import traceback
+        traceback.print_exc()
+
+    # Test 3: Get attendance (new feature)
+    print("\n[TEST 3] Getting attendance...")
+    try:
+        for student in students:
+            print(f"\n  {student.firstname} {student.lastname}:")
+            for enrollment in student.enrollments:
+                attendance = await client.attendance(enrollment.enrollmentid, student.personid)
+                for term in attendance.terms:
+                    print(f"    {term.termname}: {term.totalabsent} absences, {term.totaltardy} tardies")
+        print("  ✓ Attendance test passed")
+    except Exception as e:
+        print(f"  ✗ Failed: {e}")
+        import traceback
+        traceback.print_exc()
+
+    # Test 4: Get messages (new feature)
+    print("\n[TEST 4] Getting inbox messages...")
+    try:
+        messages = await client.messages()
+        print(f"  Found {len(messages)} messages")
+        for msg in messages[:5]:  # First 5 messages
+            print(f"\n    {msg.date}: {msg.subject}")
+            print(f"      Student: {msg.studentname}")
+            if msg.coursename:
+                print(f"      Course: {msg.coursename}")
+        print("  ✓ Messages test passed")
+    except Exception as e:
+        print(f"  ✗ Failed: {e}")
+        import traceback
+        traceback.print_exc()
+
+    # Test 5: Get message detail (new feature)
+    print("\n[TEST 5] Getting message detail...")
+    try:
+        if messages:
+            msg = messages[0]
+            detail = await client.message_detail(msg)
+            if detail.body_text:
+                preview = detail.body_text[:200] + "..." if len(detail.body_text) > 200 else detail.body_text
+                print(f"  Subject: {detail.subject}")
+                print(f"  Content preview: {preview}")
+            print("  ✓ Message detail test passed")
+        else:
+            print("  ⚠ No messages to test detail")
+    except Exception as e:
+        print(f"  ✗ Failed: {e}")
+        import traceback
+        traceback.print_exc()
+
+    print("\n" + "=" * 60)
+    print("All tests completed!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(test_all_features())


### PR DESCRIPTION
## Summary

This PR adds support for three new data types that were missing from the API:

- **Grades** - Posted and in-progress grades organized by term
- **Attendance** - Absences and tardies by term  
- **Messages** - Inbox messages from teachers/school with full content retrieval

## New API Endpoints Discovered

| Feature | Endpoint |
|---------|----------|
| Grades | `/campus/resources/portal/grades?personID={id}` |
| Attendance | `/campus/resources/portal/attendance/{enrollmentID}?courseSummary=true&personID={id}` |
| Messages | `/campus/api/portal/process-message` |
| Message Detail | `/campus/prism?x=messenger.MessengerEngine-getMessageRecipientView&...` |

## New Methods

```python
# Get grades for a student
grades = await client.grades(student.personid)
for grade in grades:
    for term in grade.terms:
        for course in term.courses:
            print(f"{course.coursename}: {course.grade}")

# Get attendance
attendance = await client.attendance(enrollment.enrollmentid, student.personid)
for term in attendance.terms:
    print(f"{term.termname}: {term.totalabsent} absences")

# Get inbox messages
messages = await client.messages()
for msg in messages:
    print(f"{msg.date}: {msg.subject}")
    detail = await client.message_detail(msg)
    print(detail.body_text)  # HTML stripped
```

## New Model Classes

- `Grade`, `GradeTerm`, `GradeCourse`, `GradingTask`
- `Attendance`, `AttendanceTerm`, `AttendanceCourse`  
- `Message`, `MessageDetail`

## Test Plan

- [x] Tested with real Infinite Campus account (District 196, MN)
- [x] Verified grades return posted scores and in-progress scores
- [x] Verified attendance returns absences/tardies by term
- [x] Verified messages returns inbox with 121 messages
- [x] Verified message_detail returns full content with HTML stripped