### PR TITLE
Change middleName to be optional in base model

### DIFF
--- a/src/ic_parent_api/models/base.py
+++ b/src/ic_parent_api/models/base.py
@@ -47,7 +47,7 @@ class StudentResponse(BaseModel):
     guardian: bool
     firstName: str
     lastName: str
-    middleName: str
+    middleName: Optional[str] = None
     suffix: Optional[str] = None
     alias: Optional[str] = None
     studentNumber: int


### PR DESCRIPTION
Not all school districts populate the student's middle name.  Modified middleName to be optional.